### PR TITLE
libusb-rs: point to latest commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Kevin Mehall <km@kevinmehall.net>"]
 
 [dependencies]
-libusb = { git="https://github.com/kevinmehall/libusb-rs.git", rev="3de038759f7c64a409a5d578b307a40e04a949a1" }
+libusb = { git="https://github.com/kevinmehall/libusb-rs.git", rev="6a88815888463dcd11cade340cdb23b8ee6de853" }


### PR DESCRIPTION
I suspect you did a rebase in libusb-rs and git won't serve the commit anymore.
